### PR TITLE
Create StringBackedEnumTrait

### DIFF
--- a/Enums/StringBackedEnumTrait.php
+++ b/Enums/StringBackedEnumTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Bytes\EnumSerializerBundle\Enums;
+
+use BackedEnum;
+use ValueError;
+
+/**
+ * @method static string[] values()
+ */
+trait StringBackedEnumTrait
+{
+    use BackedEnumTrait;
+
+    /**
+     * @param BackedEnum|string $value
+     * @return string
+     */
+    public static function normalizeToValue(self|string $value): string
+    {
+        if ($value instanceof static) {
+            return $value->value;
+        } elseif (!is_null(static::tryFrom($value))) {
+            return $value;
+        } else {
+            throw new ValueError(sprintf('The value "%s" is not a value for the "%s" enum.', $value, __CLASS__));
+        }
+    }
+
+    /**
+     * @param BackedEnum|string $value
+     * @return static
+     */
+    public static function normalizeToEnum(self|string $value): static
+    {
+        if ($value instanceof static) {
+            return $value;
+        }
+
+        $value = static::tryFrom($value);
+        if (!is_null($value)) {
+            return $value;
+        } else {
+            throw new ValueError(sprintf('The value "%s" is not a value for the "%s" enum.', $value, __CLASS__));
+        }
+    }
+}

--- a/Tests/Enums/EnumTest.php
+++ b/Tests/Enums/EnumTest.php
@@ -2,8 +2,11 @@
 
 namespace Bytes\EnumSerializerBundle\Tests\Enums;
 
+use Bytes\EnumSerializerBundle\PhpUnit\EnumAssertions;
 use Bytes\EnumSerializerBundle\Tests\Fixtures\BackedEnum;
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ValueError;
 
 class EnumTest extends TestCase
 {
@@ -46,5 +49,80 @@ class EnumTest extends TestCase
         $this->assertTrue(BackedEnum::VALUE_A->equals(BackedEnum::tryFrom('a'), BackedEnum::VALUE_A));
         $this->assertTrue(BackedEnum::VALUE_A->equals(BackedEnum::tryFrom('a'), BackedEnum::tryFrom('b')));
         $this->assertFalse(BackedEnum::VALUE_A->equals(BackedEnum::tryFrom('b')));
+    }
+
+    /**
+     * @dataProvider provideAll
+     * @param $enum
+     * @param $value
+     * @return void
+     */
+    public function testAll($enum, $value)
+    {
+        EnumAssertions::assertIsEnum($enum);
+        EnumAssertions::assertEqualsEnum($enum, $value);
+        EnumAssertions::assertSameEnumValue($enum, $value);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideAll(): Generator
+    {
+        foreach (BackedEnum::cases() as $enum) {
+            yield $enum->value => ['enum' => $enum, 'value' => $enum->value];
+        }
+    }
+
+    /**
+     * @dataProvider provideChoices
+     * @param $choices
+     * @return void
+     */
+    public function testChoices($choices)
+    {
+        $this->assertEquals($choices, BackedEnum::easyAdminChoices());
+        $this->assertEquals($choices, BackedEnum::formChoices());
+    }
+
+    public function provideChoices()
+    {
+        yield 'choices' => [['Value A' => 'a', 'Value B' => 'b']];
+    }
+
+    /**
+     * @dataProvider provideAll
+     * @param $enum
+     * @param $value
+     * @return void
+     */
+    public function testNormalizeToValueSuccess($enum, $value)
+    {
+        $this->assertEquals($value, BackedEnum::normalizeToValue($value));
+        $this->assertEquals($value, BackedEnum::normalizeToValue($enum));
+    }
+
+    public function testNormalizeToValueFailure()
+    {
+        $this->expectException(ValueError::class);
+        BackedEnum::normalizeToValue('abc123');
+    }
+
+    /**
+     * @dataProvider provideAll
+     * @param $enum
+     * @param $value
+     * @return void
+     */
+    public function testNormalizeToEnumSuccess($enum, $value)
+    {
+        $this->assertEquals($enum, BackedEnum::normalizeToEnum($value));
+        $this->assertEquals($enum, BackedEnum::normalizeToEnum($enum));
+    }
+
+    public function testNormalizeToEnumFailure()
+    {
+        $this->expectException(ValueError::class);
+        BackedEnum::normalizeToEnum('abc123');
     }
 }

--- a/Tests/Fixtures/BackedEnum.php
+++ b/Tests/Fixtures/BackedEnum.php
@@ -2,11 +2,11 @@
 
 namespace Bytes\EnumSerializerBundle\Tests\Fixtures;
 
-use Bytes\EnumSerializerBundle\Enums\BackedEnumTrait;
+use Bytes\EnumSerializerBundle\Enums\StringBackedEnumTrait;
 
 enum BackedEnum: string
 {
-    use BackedEnumTrait;
+    use StringBackedEnumTrait;
 
     case VALUE_A = 'a';
     case VALUE_B = 'b';


### PR DESCRIPTION
Potentially Breaking Change: any 2.0.0-BETA1 compatible string backed enums that use `BackedEnumTrait` should now use `StringBackedEnumTrait`