### PR TITLE
Allow passing of a filtered list of choices to provideFormChoices()/provideFormEnums()

### DIFF
--- a/Enums/BackedEnumTrait.php
+++ b/Enums/BackedEnumTrait.php
@@ -15,12 +15,13 @@ trait BackedEnumTrait
     use UnitEnumTrait;
 
     /**
-     * @return array<string>
+     * @param array<BackedEnum> $cases
+     * @return array<string, string>
      */
-    public static function provideFormChoices(): array
+    public static function provideFormChoices(?array $cases = null): array
     {
         $return = [];
-        foreach (static::cases() as $value) {
+        foreach (($cases ?? static::cases()) as $value) {
             $return[static::getFormChoiceKey($value)] = static::getFormChoiceValue($value);
         }
 
@@ -29,14 +30,15 @@ trait BackedEnumTrait
 
     /**
      * For usage in EasyAdminBundle until such time that #4988 is resolved
+     * @param array<BackedEnum> $cases
      * @return array<string, static>
      *
      * @link https://github.com/EasyCorp/EasyAdminBundle/pull/4988
      */
-    public static function provideFormEnums(): array
+    public static function provideFormEnums(?array $cases = null): array
     {
         $return = [];
-        foreach (static::cases() as $value) {
+        foreach (($cases ?? static::cases()) as $value) {
             $return[static::getFormChoiceKey($value)] = $value;
         }
 

--- a/Tests/Enums/EnumTest.php
+++ b/Tests/Enums/EnumTest.php
@@ -101,6 +101,30 @@ class EnumTest extends TestCase
     }
 
     /**
+     * @dataProvider providePartialChoices
+     * @param array<string, string> $manualValue
+     * @param array<string, BackedEnum> $manualEnum
+     * @param BackedEnum[]|null $enum
+     * @return void
+     */
+    public function testPartialChoices($manualValue, $manualEnum, $enum): void
+    {
+        $this->assertEquals($manualValue, BackedEnum::provideFormChoices($enum));
+    }
+
+    /**
+     * @return Generator
+     */
+    public function providePartialChoices(): Generator
+    {
+        yield 'A' => ['manualValue' => ['Value A' => 'a'], 'manualEnum' => ['Value A' => BackedEnum::VALUE_A], 'enum' => [BackedEnum::VALUE_A]];
+        yield 'B' => ['manualValue' => ['Value B' => 'b'], 'manualEnum' => ['Value B' => BackedEnum::VALUE_B], 'enum' => [BackedEnum::VALUE_B]];
+        yield 'All' => ['manualValue' => ['Value A' => 'a', 'Value B' => 'b'], 'manualEnum' => ['Value A' => BackedEnum::VALUE_A, 'Value B' => BackedEnum::VALUE_B], 'enum' => BackedEnum::cases()];
+        yield 'null' => ['manualValue' => ['Value A' => 'a', 'Value B' => 'b'], 'manualEnum' => ['Value A' => BackedEnum::VALUE_A, 'Value B' => BackedEnum::VALUE_B], 'enum' => null];
+        yield 'empty' => ['manualValue' => [], 'manualEnum' => [], 'enum' => []];
+    }
+
+    /**
      * @dataProvider provideEnumChoices
      * @param $choices
      * @return void
@@ -116,6 +140,18 @@ class EnumTest extends TestCase
     public function provideEnumChoices()
     {
         yield 'choices' => [['Value A' => BackedEnum::VALUE_A, 'Value B' => BackedEnum::VALUE_B]];
+    }
+
+    /**
+     * @dataProvider providePartialChoices
+     * @param array<string, string> $manualValue
+     * @param array<string, BackedEnum> $manualEnum
+     * @param BackedEnum[]|null $enum
+     * @return void
+     */
+    public function testPartialEnumChoices($manualValue, $manualEnum, $enum)
+    {
+        $this->assertEquals($manualEnum, BackedEnum::provideFormEnums($enum));
     }
 
     /**


### PR DESCRIPTION
Add optional parameter to `provideFormChoices()`/`provideFormEnums()` to allow passing of a filtered list of choices

Updated version of #33 for v4