### PR TITLE
Add "void" as a native return type to BytesEnumSerializerExtension

### DIFF
--- a/DependencyInjection/BytesEnumSerializerExtension.php
+++ b/DependencyInjection/BytesEnumSerializerExtension.php
@@ -27,7 +27,7 @@ class BytesEnumSerializerExtension extends Extension implements ExtensionInterfa
      * @throws Exception     *
      * @throws InvalidArgumentException When provided tag is not defined in this extension
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.php');


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future.